### PR TITLE
fixed build with recent toolchain

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,6 +38,7 @@ build() {
   cd ${srcdir}/faup1090
   git fetch --all
   git reset --hard origin/master
+  patch -p0 -i ../../faup1090-Makefile.patch
   make faup1090
 
 ## Build piaware

--- a/faup1090-Makefile.patch
+++ b/faup1090-Makefile.patch
@@ -1,0 +1,11 @@
+--- Makefile~	2024-06-18 10:04:20.000000000 -0400
++++ Makefile	2024-06-18 10:21:31.375001131 -0400
+@@ -3,7 +3,7 @@
+ DUMP1090_VERSION ?= unknown
+ 
+ CFLAGS ?= -O3 -g
+-DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -Wformat-signedness -W
++DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Wformat-signedness -W
+ DUMP1090_CPPFLAGS := -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\"
+ 
+ LIBS = -lpthread -lm


### PR DESCRIPTION
Latest compilers on arch with most recent code tree generate a warning and `-Werror` will kill the build. 